### PR TITLE
Auditoría de UI en mobile: formato de números, desborde, área táctil y dos series sin backfill

### DIFF
--- a/projects/informe_coyuntura/scripts/descargar_series.py
+++ b/projects/informe_coyuntura/scripts/descargar_series.py
@@ -1390,6 +1390,46 @@ def _utdt_xls(listado_url):
     return x.content
 
 
+def _utdt_niveles(listado_url) -> dict:
+    """{YYYY-MM: nivel} del XLS de una serie histórica de la UTDT.
+
+    Todas las planillas comparten el layout (col 0 fecha, col 1 valor), así que
+    el parseo va una sola vez: había tres copias del mismo loop en este archivo
+    y de ahí salían las divergencias entre la card y su serie."""
+    import xlrd
+    wb = xlrd.open_workbook(file_contents=_utdt_xls(listado_url))
+    ws = wb.sheets()[0]
+    out = {}
+    for i in range(ws.nrows):
+        fc, vc = ws.cell(i, 0), ws.cell(i, 1)
+        if fc.ctype == xlrd.XL_CELL_DATE and vc.ctype == xlrd.XL_CELL_NUMBER:
+            t = xlrd.xldate_as_tuple(fc.value, wb.datemode)
+            out[f"{t[0]}-{t[1]:02d}"] = vc.value
+    return out
+
+
+def fetch_indice_lider_serie(meses: int = 60) -> list:
+    """NIVEL del Índice Líder de la UTDT — el mismo número que publica la card.
+
+    Segundo caso del mismo defecto que `alquiler_real` (auditoría de UI
+    29-jul-2026): la card puntúa —13% de la dimensión empleo del ITVC— y su
+    serie tenía un solo punto porque nunca se registró acá. El componente
+    rebaseado (`itvc_lider`) sí tenía historia, pero es otra escala: 100 =
+    4T-2023, no el nivel que muestra la card.
+
+    Redondeo a 1 decimal, igual que la card en publicar.py, para que G3 cierre.
+
+    Acotada a `meses` como la del ICC: el XLS de la UTDT arranca en 1993 y son
+    402 puntos. No es que sobre historia, es que la sparkline de la card
+    comprime 33 años y el movimiento reciente —lo que la card informa— queda
+    invisible. 60 meses quedan muy por encima del piso de dic-2023.
+    [[YYYY-MM-01, índice]]."""
+    sys.path.insert(0, str(Path(__file__).parent / "vida_cotidiana"))
+    from config import UTDT_IL_LISTADO
+    niveles = sorted(_utdt_niveles(UTDT_IL_LISTADO).items())
+    return [[f"{ym}-01", round(v, 1)] for ym, v in niveles][-meses:]
+
+
 def fetch_itvc_lider() -> list:
     """I_IL (ADR-0112): Índice Líder de la UTDT rebaseado a 4T-2023.
 
@@ -1398,22 +1438,17 @@ def fetch_itvc_lider() -> list:
     pasó. Se rebasea igual que los demás (100 = 4T-2023) y NO se invierte:
     un líder más alto anticipa mejor actividad, que es mejora.
     [[YYYY-MM-01, índice]]."""
-    import xlrd
     sys.path.insert(0, str(Path(__file__).parent / "vida_cotidiana"))
     from config import UTDT_IL_LISTADO
-    wb = xlrd.open_workbook(file_contents=_utdt_xls(UTDT_IL_LISTADO))
-    ws = wb.sheets()[0]
-    crudo = {}
-    for i in range(ws.nrows):
-        fc, vc = ws.cell(i, 0), ws.cell(i, 1)
-        if fc.ctype == xlrd.XL_CELL_DATE and vc.ctype == xlrd.XL_CELL_NUMBER:
-            t = xlrd.xldate_as_tuple(fc.value, wb.datemode)
-            crudo[f"{t[0]}-{t[1]:02d}"] = vc.value
-    return _itvc_rebase(crudo)
+    return _itvc_rebase(_utdt_niveles(UTDT_IL_LISTADO))
 
 
 VIDA_DERIVADAS.append(
     ("itvc_lider", "índice (100 = 4T-2023)", "UTDT — Índice Líder (serie XLS)", fetch_itvc_lider)
+)
+# Unidad y fuente COPIADAS de la card (publicar.py)
+VIDA_DERIVADAS.append(
+    ("indice_lider", "índice", "UTDT — Índice Líder (CIF)", fetch_indice_lider_serie)
 )
 VIDA_DERIVADAS.append(
     ("pobreza_nowcast", "% de personas", "UTDT — Nowcast de Pobreza (informes PDF)",
@@ -1613,6 +1648,32 @@ def fetch_itvc_alimentos() -> list:
         indice = (a_base / alim[ym]) * (gen[ym] / g_base) * 100.0
         out.append([f"{ym}-01", round(indice, 1)])
     return out
+
+
+def fetch_alquiler_real_serie() -> list:
+    """% m/m del IPC-GBA «alquiler de la vivienda» — la misma cuenta que la card.
+
+    La card era la ÚNICA de las 25 de la home sin sparkline, y no era un problema
+    de UI: `alquiler_real` nunca se registró acá, así que su serie tenía un solo
+    punto —el valor del día— cuando la regla del proyecto pide backfill desde
+    dic-2023 (auditoría de UI 29-jul-2026). El componente del ITVC
+    (`itvc_alquiler`) sí tenía historia, pero **mide otra cosa**: encarecimiento
+    relativo al nivel general de GBA, no la variación mensual del alquiler. No
+    son intercambiables.
+
+    Se deriva del NIVEL con `_var_mensual`, que exige meses CONSECUTIVOS, en vez
+    de dividir posiciones adyacentes de la lista descargada: si INDEC saltea un
+    mes, el cociente entre dos observaciones separadas por dos meses se
+    publicaría como variación mensual sin que nada avise (el mismo error que
+    corrigió la auditoría del 18-jul-2026).
+
+    Misma fórmula y mismo redondeo que la card, para que G3 cierre:
+    `(idx_t / idx_{t-1} − 1) × 100` a dos decimales.
+    [[YYYY-MM-01, % m/m]]."""
+    sys.path.insert(0, str(Path(__file__).parent / "vida_cotidiana"))
+    from config import INDEC_SERIES
+    niveles = _nivel_mensual(INDEC_SERIES["ipc_alquiler_gba"])
+    return [[f"{ym}-01", v] for ym, v in sorted(_var_mensual(niveles).items())]
 
 
 def fetch_itvc_alquiler() -> list:
@@ -2043,6 +2104,12 @@ VIDA_DERIVADAS += [
     ("itvc_alimentos", "índice (100 = 4T-2023)", "INDEC IPC Alimentos + IPC general (elab. CIGOB)", fetch_itvc_alimentos),
     ("itvc_tarifas", "índice (100 = 4T-2023)", "INDEC IPC Regulados + RIPTE (elab. CIGOB)", fetch_itvc_tarifas),
     ("itvc_alquiler", "índice (100 = 4T-2023)", "INDEC IPC-GBA alquiler + nivel general GBA (elab. CIGOB)", fetch_itvc_alquiler),
+    # La card de alquiler, con historia. Va acá y no en el literal de
+    # VIDA_DERIVADAS de más arriba porque ese se evalúa antes de que existan
+    # estas funciones. Unidad y fuente COPIADAS de la card (publicar.py): si
+    # divergen, la ficha pública dice una cosa y el CSV de la serie otra.
+    ("alquiler_real", "% m/m alquileres",
+     "INDEC — IPC-GBA alquiler de la vivienda (vía datos.gob.ar)", fetch_alquiler_real_serie),
     ("itvc_ipi", "índice (100 = 4T-2023)", "INDEC IPI desestacionalizado", fetch_itvc_ipi),
     ("itvc_isac", "índice (100 = 4T-2023)", "INDEC ISAC desestacionalizado", fetch_itvc_isac),
     ("itvc_endeudamiento", "índice real (100 = 4T-2023)", "BCRA Informe sobre Bancos (familias) + IPC INDEC", fetch_itvc_endeudamiento),

--- a/projects/informe_coyuntura/scripts/publicar.py
+++ b/projects/informe_coyuntura/scripts/publicar.py
@@ -24,6 +24,23 @@ import itvc                                           # pesos y rebase del ITVC 
 import sensibilidad                                   # rango de robustez (ADR-0019)
 
 
+def coma(x) -> str:
+    """Número para texto PÚBLICO: coma decimal es-AR y menos tipográfico (U+2212).
+
+    Había trece copias de `coma = lambda x: str(x).replace(".", ",")` en este
+    archivo, todas sin el signo menos — y por eso las conclusiones de validación
+    salían con guion («ITCM -0,84 con el riesgo país») mientras las unidades y
+    las anclas que escribe el pipeline usan «−». Lo encontró la auditoría de UI
+    del 29-jul-2026, que vio los dos signos en la misma página.
+
+    Sólo se convierte el menos INICIAL, a propósito: el guion interno de una
+    fecha o de un rango («2026-06-01», «1997-2026») no es un signo menos y
+    convertirlo rompería el texto.
+    """
+    s = str(x).replace(".", ",")
+    return ("−" + s[1:]) if s.startswith("-") else s
+
+
 def _add(out, key, valor, unidad, fuente, fecha, **extra):
     d = {"valor": valor, "unidad": unidad, "fuente": fuente,
          "fecha_dato": fecha, "desactualizado": False}
@@ -408,7 +425,6 @@ def _scoring_indice(c, clave, mod, contexto_txt, input_txt_fn):
 def _macro_input_txt(ikey, ind):
     """'Valor usado' que muestra el modal: la descomposición del número que
     realmente se puntúa (no siempre coincide con el valor mostrado)."""
-    coma = lambda x: str(x).replace(".", ",")    # decimal es-AR, sin tocar el resto
     if ikey == "rem_ipc_12m" and ind.get("equivalente_mensual") is not None:
         return (f"equiv. mensual {coma(ind['equivalente_mensual'])}% "
                 f"(raíz-12 del {coma(ind.get('valor'))}% anual)")
@@ -457,7 +473,6 @@ def _macro_input_txt(ikey, ind):
 def _gestion_input_txt(ikey, ind):
     """'Valor usado' del modal para gestión: la descomposición del número que
     puntúa (compuestos como el ILCE o el Fondo de Cese exponen componentes)."""
-    coma = lambda x: str(x).replace(".", ",")
     if ind.get("detalle_txt"):                       # detalle rico (ej. RIGI oficial)
         return ind["detalle_txt"]
     if ikey == "fal_modernizacion_laboral" and ind.get("componentes"):
@@ -475,7 +490,6 @@ def _politica_input_txt(ikey, ind):
     puntúa (protestas_caba puntúa sobre la variación vs. 2023, no el conteo
     crudo de eventos; adhesion_reformas_provincial expone la cuenta de
     provincias detrás del %)."""
-    coma = lambda x: str(x).replace(".", ",")
     if ind.get("detalle_txt"):                       # detalle rico (ej. protestas_caba, ACLED)
         return ind["detalle_txt"]
     if ikey == "adhesion_reformas_provincial" and ind.get("n_provincias") is not None:
@@ -664,7 +678,6 @@ def _validacion_itvc(bloque, series):
     corr = val.get("correlaciones", {})
     niveles = corr.get("niveles (ITVC sin ICC vs ICC)") or {}
     difs = corr.get("primeras diferencias (sin ICC)") or {}
-    coma = lambda x: str(x).replace(".", ",")
     r_niv, r_dif = niveles.get("r"), difs.get("r")
     bloque["validacion"] = {
         "r_niveles": r_niv, "r_diferencias": r_dif, "n": niveles.get("n"),
@@ -706,7 +719,6 @@ def _validacion_itcm(bloque):
     corr = val.get("correlaciones_itcm", {})
     niveles = corr.get("niveles (ITCM vs riesgo país)") or {}
     difs = corr.get("primeras diferencias (ITCM vs riesgo)") or {}
-    coma = lambda x: str(x).replace(".", ",")
     r_niv, r_dif = niveles.get("r"), difs.get("r")
 
     def _r(a, b):
@@ -801,7 +813,6 @@ def _redundancia(bloque, clave_val: str):
     red = _cargar_validacion().get(clave_val) or {}
     if red.get("r_abs_medio") is None:
         return
-    coma = lambda x: str(x).replace(".", ",")
     n_alt = len(red.get("pares_altos") or [])
     dif = red.get("diferencias") or {}
     # Se emiten las CLAVES: las etiquetas legibles viven en el front
@@ -895,7 +906,6 @@ def _linea_base(bloque):
         return
 
     brecha = actual - valor_base
-    coma = lambda x: str(x).replace(".", ",")
     mes_base = "diciembre de 2023"
     signo = "arriba del" if brecha >= 0 else "abajo del"
 
@@ -955,7 +965,6 @@ def _rezago(bloque, rezago_meses: dict, pulso: float, estructural: float):
     rezagados = [{"indicador": k, "meses": m}
                  for k, _, m in sorted(filas, key=lambda x: -x[2]) if m >= estructural]
 
-    coma = lambda x: str(x).replace(".", ",")
     prom_txt = coma(round(promedio, 1))
     bloque["rezago"] = {
         "promedio_meses": round(promedio, 1),
@@ -1029,7 +1038,6 @@ def _familias(bloque, familias: dict, meta_familias: dict):
     familias_out.sort(key=lambda f: f["puntaje"])
 
     peor, mejor = familias_out[0], familias_out[-1]
-    coma = lambda x: str(x).replace(".", ",")
     brecha = round(mejor["puntaje"] - peor["puntaje"], 1)
 
     bloque["familias"] = {
@@ -1125,7 +1133,6 @@ def _vintages(cinturon, indice_key):
                        key=lambda f: -f["dias"])
 
     meses = lambda d: round(d / 30.44, 1)
-    coma = lambda x: str(x).replace(".", ",")
     _MESES_ES_LARGO = ("enero", "febrero", "marzo", "abril", "mayo", "junio", "julio",
                        "agosto", "septiembre", "octubre", "noviembre", "diciembre")
 
@@ -1292,7 +1299,6 @@ def _validacion_itcg(bloque):
     niveles = corr.get("niveles (ITCG vs Merval USD)") or {}
     difs = corr.get("primeras diferencias (ITCG vs Merval USD)") or {}
     icg_niv = (corr.get("niveles (ITCG vs ICG)") or {}).get("r")
-    coma = lambda x: str(x).replace(".", ",")
     r_niv, r_dif = niveles.get("r"), difs.get("r")
     icg_txt = ""
     if icg_niv is not None:
@@ -1340,7 +1346,6 @@ def _validacion_itcp(bloque):
     # que es la más nueva y la que este contraste no cubre. Se publica.
     r_sin_priv = (corr.get("niveles, sin la dimensión de sector privado") or {}).get("r")
     difs = corr.get("primeras diferencias (ITCP vs EPU)") or {}
-    coma = lambda x: str(x).replace(".", ",")
     r_niv, r_dif = niveles.get("r"), difs.get("r")
     bloque["validacion"] = {
         "r_niveles": r_niv, "r_diferencias": r_dif, "n": niveles.get("n"),
@@ -1421,7 +1426,6 @@ def _scoring_vida_itvc(c, series):
             for ikey, info in dim["indicadores"].items():
                 por_ind[ikey] = (dkey, info)
     en_itvc = {k for d in itvc.DIMENSIONES_ITVC.values() for k in d["indicadores"]}
-    coma = lambda x: str(x).replace(".", ",")
     for ikey, ind in c["indicadores"].items():
         aporte = formula = nota = lectura = None
         if ikey in por_ind:

--- a/projects/informe_coyuntura/tests/test_fichas_pesos.py
+++ b/projects/informe_coyuntura/tests/test_fichas_pesos.py
@@ -1,0 +1,106 @@
+"""Las fichas metodológicas públicas no pueden afirmar ponderaciones que el
+índice ya no usa.
+
+Las fichas de /metodologia dicen cosas como «Pertenece a la dimensión de
+prospectivas de empleo (20% interno · 3% del ITVC)». Ese número es verdadero el
+día que se escribe y queda mentiroso la próxima vez que entra un indicador a la
+misma dimensión: los existentes ceden peso proporcionalmente y nadie vuelve al
+texto. Cuando `empleo_registrado` entró con 35%, los cuatro componentes de
+prospectivas de empleo cedieron ×0,65 y las cuatro fichas siguieron publicando
+los pesos viejos.
+
+Lo encontró una auditoría de UI (29-jul-2026) de casualidad, mirando el Índice
+Líder: la ficha decía 20% interno · 3% del ITVC cuando el real era 13% · 1,95%.
+Al medirlo en todas, había DOCE fichas con el peso stale, y varias además con el
+nombre de la dimensión anterior a su reorganización («confianza y seguridad»,
+que hoy son dos dimensiones distintas).
+
+Ningún gate podía verlo: gate_calidad.py valida datos y estructura del snapshot,
+nunca cruza la prosa de la capa de display contra los pesos que usa el motor.
+Mismo hueco que cerró test_web_labels.py para los rótulos.
+
+Qué NO se valida acá, a propósito:
+  · las entradas de `cambios`, que son un changelog — dicen el peso que tenía el
+    indicador ESE día y tienen que quedar como están;
+  · las frases que citan el peso de la DIMENSIÓN («la dimensión de vulnerabilidad
+    financiera (10% del ITVC), donde pesa 50%»), que son otra afirmación.
+Sólo se cruza el par «N% interno · M% del ÍNDICE», que es la forma que se copió
+y quedó vieja.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHAS = (ROOT / "web/src/lib/fichas.ts").read_text(encoding="utf-8")
+INFORME = json.loads((ROOT / "web/src/data/informe.json").read_text(encoding="utf-8-sig"))
+
+TOLERANCIA_PP = 0.6      # el texto redondea; 0,6 pp deja pasar 3,15 vs 3,1
+
+
+def _pesos_reales() -> dict:
+    out = {}
+    for c in INFORME["cinturones"].values():
+        for sigla in ("itvc", "itcm", "itcg", "itcp"):
+            idx = c.get(sigla)
+            if not idx:
+                continue
+            for dv in (idx.get("dimensiones") or {}).values():
+                for ikey, iv in (dv.get("indicadores") or {}).items():
+                    out[ikey] = {"interno": (iv.get("peso") or 0) * 100,
+                                 "efectivo": (iv.get("peso_efectivo") or 0) * 100}
+    return out
+
+
+def _incidencia_por_ficha() -> dict:
+    """{clave: texto de incidenciaTexto}. Excluye `cambios` (changelog)."""
+    out = {}
+    for m in re.finditer(r"^  (\w+): \{$", FICHAS, re.M):
+        fin = FICHAS.find("\n  },", m.end())
+        cuerpo = FICHAS[m.end():fin]
+        inc = re.search(r"incidenciaTexto:\s*\[(.*?)\]", cuerpo, re.S)
+        if inc:
+            out[m.group(1)] = inc.group(1)
+    return out
+
+
+def _num(s: str) -> float:
+    return float(s.replace(",", "."))
+
+
+def test_los_pesos_que_afirman_las_fichas_son_los_vigentes():
+    reales = _pesos_reales()
+    problemas = []
+    for clave, texto in _incidencia_por_ficha().items():
+        real = reales.get(clave)
+        if not real:
+            continue
+        mi = re.search(r"(\d+(?:,\d+)?)\s*%\s*interno", texto)
+        if mi and abs(_num(mi.group(1)) - real["interno"]) > TOLERANCIA_PP:
+            problemas.append(f"{clave}: ficha dice {mi.group(1)}% interno, "
+                             f"real {real['interno']:.1f}%")
+        # sólo la forma "· M% del ÍNDICE", que acompaña al peso interno; la que
+        # cita el peso de la dimensión tiene otra redacción y no se toca
+        me = re.search(r"·\s*(\d+(?:,\d+)?)\s*%\s*del\s*(?:ITVC|ITCM|ITCG|ITCP)", texto)
+        if me and abs(_num(me.group(1)) - real["efectivo"]) > TOLERANCIA_PP:
+            problemas.append(f"{clave}: ficha dice {me.group(1)}% del índice, "
+                             f"real {real['efectivo']:.2f}%")
+    assert not problemas, (
+        "fichas públicas con ponderación stale (entró un indicador a la dimensión "
+        "y los demás cedieron peso sin que se actualice el texto):\n  "
+        + "\n  ".join(problemas))
+
+
+def test_el_test_mira_algo():
+    """Guarda contra que el parseo quede vacío y el test pase por no leer nada."""
+    inc = _incidencia_por_ficha()
+    reales = _pesos_reales()
+    con_peso = [k for k, t in inc.items()
+                if k in reales and re.search(r"\d+(?:,\d+)?\s*%\s*interno", t)]
+    # Al 29-jul-2026: 32 fichas con incidenciaTexto, 12 de ellas declarando peso
+    # interno — que son justo las 12 que estaban stale. Los pisos van por debajo
+    # para no romper cada vez que se suma una ficha, pero lo bastante alto como
+    # para que un parseo roto no pase inadvertido.
+    assert len(inc) >= 28, f"sólo se parsearon {len(inc)} fichas: ¿cambió el formato?"
+    assert len(con_peso) >= 10, f"sólo {len(con_peso)} fichas declaran peso interno"

--- a/projects/informe_coyuntura/tests/test_series_registradas.py
+++ b/projects/informe_coyuntura/tests/test_series_registradas.py
@@ -1,0 +1,81 @@
+"""Todo indicador publicado con valor numérico tiene que tener su serie
+registrada en descargar_series.py -- si falta, la card sale sin sparkline y sin
+histórico descargable, y nada avisa.
+
+Lo encontró una auditoría de UI (29-jul-2026) por el síntoma visual: de las 25
+filas de indicador de la home, `alquiler_real` era la única sin sparkline. No era
+un problema de front: su serie tenía UN punto —el valor del día— cuando la regla
+del proyecto pide backfill desde dic-2023. Al medir el invariante apareció un
+segundo caso idéntico, `indice_lider`, que además puntúa (13% de la dimensión
+empleo del ITVC).
+
+Los dos tenían un pariente con historia (`itvc_alquiler`, `itvc_lider`) y ahí
+estaba la trampa: parecía que la serie existía. Pero esos son los componentes
+REBASEADOS del ITVC (100 = 4T-2023) y las cards publican otra cosa —variación
+mensual y nivel—, así que no son intercambiables.
+
+Ningún gate cubría esto: gate_calidad.py compara card contra serie sólo cuando
+la serie EXISTE (G3), y si no existe no tiene con qué comparar. Este test cierra
+la clase de bug, no los dos casos puntuales.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import descargar_series as ds
+
+INFORME = json.loads((ROOT / "web/src/data/informe.json").read_text(encoding="utf-8-sig"))
+
+# Indicadores cuya serie NO se registra acá, con el motivo. Sumar una clave a
+# esta lista es una decisión explícita, no un olvido.
+SIN_SERIE_A_PROPOSITO: dict[str, str] = {}
+
+
+def _registradas() -> set:
+    """El registro autoritativo es el que resuelve `--indicador` en el CLI."""
+    nombres = set()
+    for indec, bcra, derivadas in ds.CINTURONES_SERIES.values():
+        nombres |= ds._nombres_de(indec, bcra, derivadas)
+    return nombres
+
+
+def _publicados_numericos() -> list:
+    out = []
+    for ckey, c in INFORME["cinturones"].items():
+        for ikey, ind in (c.get("indicadores") or {}).items():
+            if isinstance(ind.get("valor"), (int, float)):
+                out.append((ckey, ikey))
+    return out
+
+
+def test_todo_indicador_numerico_tiene_serie_registrada():
+    registradas = _registradas()
+    faltan = [f"{ck}/{ik}" for ck, ik in _publicados_numericos()
+              if ik not in registradas and ik not in SIN_SERIE_A_PROPOSITO]
+    assert not faltan, (
+        "sin serie registrada en descargar_series.py (card sin sparkline ni "
+        f"histórico): {faltan}. Si es a propósito, declararlo en "
+        "SIN_SERIE_A_PROPOSITO con el motivo.")
+
+
+def test_los_dos_casos_de_la_auditoria_quedan_cubiertos():
+    """Regresión explícita: son los que motivaron el test."""
+    registradas = _registradas()
+    assert "alquiler_real" in registradas
+    assert "indice_lider" in registradas
+
+
+def test_el_componente_rebaseado_no_reemplaza_a_la_card():
+    """La trampa del caso: `itvc_*` tiene historia pero es OTRA escala.
+
+    Las dos claves tienen que estar registradas por separado; si alguien borra
+    la de la card pensando que el componente del ITVC ya la cubre, vuelve el bug.
+    """
+    registradas = _registradas()
+    for card, componente in (("alquiler_real", "itvc_alquiler"),
+                             ("indice_lider", "itvc_lider")):
+        assert card in registradas and componente in registradas, (
+            f"{card} y {componente} miden cosas distintas (variación/nivel vs "
+            "índice rebaseado a 4T-2023): las dos series van registradas")

--- a/projects/informe_coyuntura/web/public/dashboard.css
+++ b/projects/informe_coyuntura/web/public/dashboard.css
@@ -182,7 +182,15 @@ em { font-family: 'Montserrat', sans-serif; font-style: italic; color: var(--cta
     margin: 0 auto 24px;
 }
 .cg-hero-stats > * { flex: 1 1 170px; max-width: 240px; }
-@media (max-width: 720px) { .cg-hero-stats { grid-template-columns: repeat(2, 1fr); } }
+/* El 2x2 de mobile era CSS MUERTO: el contenedor es flex y la regla seteaba
+   grid-template-columns, que flex ignora — las 4 cards caían una por fila y se
+   comían una pantalla entera para cuatro datos (auditoría mobile 29-jul-2026).
+   A partir de acá el contenedor SÍ es grid en ese breakpoint, y hay que
+   neutralizar el flex-basis de 170px de los hijos o vuelve a desbordar. */
+@media (max-width: 720px) {
+    .cg-hero-stats { display: grid; grid-template-columns: repeat(2, 1fr); }
+    .cg-hero-stats > * { flex: none; max-width: none; }
+}
 .cg-hero-stat {
     background: var(--paper);
     border: 1px solid var(--bd);
@@ -350,6 +358,17 @@ em { font-family: 'Montserrat', sans-serif; font-style: italic; color: var(--cta
     transition: opacity .15s, transform .15s;
 }
 .cg-genoma-seg:hover, .cg-genoma-seg:focus-visible { opacity: 1; transform: scaleY(1.35); }
+/* Área táctil, no cambio visual: el tramo mide 9px de alto y el pie de la barra
+   invita a "tocá un tramo" — 9px es la mitad de un dedo. El ::after la extiende
+   a ~45px sin mover un pixel del diseño ni del layout. Sólo en punteros
+   gruesos: en desktop el hover de 9px con mouse ya funciona y agrandar el área
+   dispararía el tooltip desde lejos. Arriba hay 12px de margen y el título (no
+   interactivo) y abajo el pie de la barra (tampoco), así que no le roba el tap
+   a nada; las filas de indicador quedan más abajo. */
+@media (pointer: coarse) {
+    .cg-genoma-seg { position: relative; }
+    .cg-genoma-seg::after { content: ""; position: absolute; left: 0; right: 0; top: -18px; bottom: -18px; }
+}
 .cg-genoma-seg:focus-visible { outline: 2px solid var(--teal); outline-offset: 2px; }
 .cg-genoma-seg.sem-verde    { background: var(--verde); }
 .cg-genoma-seg.sem-amarillo { background: var(--amarillo); }

--- a/projects/informe_coyuntura/web/public/overrides.css
+++ b/projects/informe_coyuntura/web/public/overrides.css
@@ -94,6 +94,14 @@
 .cg-tile-badge.estim  { background: var(--bg-page);       color: var(--muted); }
 .cg-tile-desc { margin: 0; font-size: 11.5px; line-height: 1.45; color: var(--muted);
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+/* En una sola columna, 2 líneas son ~10 palabras y la descripción se corta
+   justo donde empezaba a decir algo: "Cuántas de las 24 jurisdicciones del país
+   (23 provincias y la Ciudad de Buenos Aires) figuran…". En desktop las tiles
+   van en grilla y el clamp de 2 mantiene las alturas parejas; en una columna esa
+   razón no aplica, así que se afloja a 4. Sigue acotado: no es quitar el clamp. */
+@media (max-width: 560px) {
+  .cg-tile-desc { -webkit-line-clamp: 4; }
+}
 .cg-tile-value { display: flex; align-items: baseline; gap: 6px; margin-top: 2px; }
 .cg-tile-num { font-family: 'JetBrains Mono', monospace; font-size: 23px; font-weight: 700; color: var(--dark); line-height: 1; }
 .cg-tile-unit { font-size: 12px; color: var(--muted); font-weight: 500; }
@@ -220,7 +228,14 @@
   .cg-ind-sparkline { flex-basis: 46px; }
   .cg-ind-value { font-size: 12px; gap: 5px; }
   .cg-ind-value .cg-ind-unit { font-size: 10px; }
-  .cg-hero-stats { grid-template-columns: 1fr; }
+  /* Se mantiene el 2x2 también acá. Esta regla decía `1fr` desde que se
+     escribió, pero nunca corrió: el contenedor era flex e ignoraba
+     grid-template-columns, así que nadie vio la diferencia entre una y dos
+     columnas a este ancho. Con el contenedor ya en grid, `1fr` dejaría las 4
+     cards apiladas justo en el ancho más común de teléfono (390px = iPhone
+     12-15), que es el problema que la auditoría marcó: una pantalla entera
+     para cuatro datos. Verificado sin desborde a 390px. */
+  .cg-hero-stats { grid-template-columns: repeat(2, 1fr); gap: 12px; }
   /* filas con chips nowrap: en teléfonos angostos pueden envolver */
   .cg-rob-head { flex-wrap: wrap; }
   .cg-rob-head span:last-child { white-space: normal; }
@@ -1003,6 +1018,16 @@ a.cg-dicc-row:hover { box-shadow: var(--shadow-hover); transform: translateY(-2p
 @media (max-width: 34rem) {
   .cg-vin-hero { gap: 18px; }
   .cg-vin-num { font-size: 29px; }
+  /* ÚNICA fuente de scroll horizontal del sitio en mobile (auditoría 29-jul-2026:
+     /gestion/ daba scrollWidth 395 contra un viewport de 390). El culpable es
+     este li: `justify-content: space-between` con el nombre del indicador a la
+     izquierda y `.cg-vin-meses` a la derecha en `white-space: nowrap` — y la
+     fecha larga ("31 de diciembre de 2025 · 6,9 meses") no puede encogerse ni
+     cortarse, así que empuja el li fuera del viewport. Se apila en vez de
+     sacarle el nowrap: mantiene la fecha entera en una línea, que es lo que el
+     nowrap protege (mismo problema que el comentario de la matriz sobre el
+     escalado de fuente de Android partiendo "30 meses"). */
+  .cg-vin-lista li { flex-direction: column; align-items: flex-start; gap: 2px; }
 }
 
 

--- a/projects/informe_coyuntura/web/src/components/Archivo.astro
+++ b/projects/informe_coyuntura/web/src/components/Archivo.astro
@@ -1,5 +1,5 @@
 ---
-import { informe, cinturonesRojos, mesLegible } from "../lib/datos.ts";
+import { informe, cinturonesRojos, mesLegible, num } from "../lib/datos.ts";
 const rojos = cinturonesRojos(informe);
 ---
 <section class="cg-section" id="archivo">
@@ -11,7 +11,7 @@ const rojos = cinturonesRojos(informe);
   <div class="cg-archive">
     <article class="cg-archive-card current">
       <div class="cg-archive-period">{mesLegible(informe.period)}</div>
-      <div class="cg-archive-bluf">Resumen editorial pendiente. Score global {informe.score_global}/10, riesgo dominante {informe.barbarismo_activo}.</div>
+      <div class="cg-archive-bluf">Resumen editorial pendiente. Score global {num(informe.score_global)}/10, riesgo dominante {informe.barbarismo_activo}.</div>
       <div class="cg-archive-foot">
         <span class:list={["cg-archive-score", `rojos-${rojos}`]}>{rojos} en rojo</span>
       </div>

--- a/projects/informe_coyuntura/web/src/components/Bluf.astro
+++ b/projects/informe_coyuntura/web/src/components/Bluf.astro
@@ -1,11 +1,10 @@
 ---
-import { informe, cap, mesLegible, CINTURONES, verdictDeCinturon, peorDimension } from "../lib/datos.ts";
+import { informe, cap, mesLegible, CINTURONES, verdictDeCinturon, peorDimension, num } from "../lib/datos.ts";
 
 // Síntesis AUTOMÁTICA del tablero (sin placeholder editorial en producción):
 // se arma de los mismos datos del snapshot, así nunca queda vieja ni vacía.
 // La lectura editorial firmada del equipo se suma con cada edición mensual;
 // mientras no exista, esta síntesis es honesta sobre su origen (ver nota).
-const coma = (n: number) => String(n).replace(".", ",");
 const estados = CINTURONES.map(m => ({ meta: m, c: informe.cinturones[m.key] }))
   .filter(x => x.c);
 const porVerdict = (v: string) => estados.filter(x => verdictDeCinturon(x.c.estado) === v);
@@ -26,7 +25,7 @@ const frases: string[] = [];
 if (rojos.length > 0) {
   frases.push(`${cap(nombres(rojos))} ${rojos.length === 1 ? "está" : "están"} en zona crítica`);
 }
-frases.push(`Con una tensión global de ${coma(informe.score_global)}/10, ${masTenso.meta.nombre.toLowerCase()} es el cinturón más exigido del tablero (${coma(masTenso.c.score)}/10)`);
+frases.push(`Con una tensión global de ${num(informe.score_global)}/10, ${masTenso.meta.nombre.toLowerCase()} es el cinturón más exigido del tablero (${num(masTenso.c.score)}/10)`);
 if (amarillos.length > 0 && !amarillos.includes(masTenso)) {
   frases.push(`${nombres(amarillos)} ${amarillos.length === 1 ? "opera" : "operan"} en tensión`);
 } else if (amarillos.length > 1) {
@@ -37,7 +36,7 @@ if (verdes.length > 0) {
 }
 const fraseEstados = frases.join("; ") + ".";
 const fraseFoco = foco
-  ? `La mayor presión puntual del mes está en ${foco.dim.nombre.toLowerCase()} (${coma(foco.dim.puntaje)}${foco.dim.base100 ? "" : "/100"}), la dimensión que más tensión aporta al índice de ${foco.meta.nombre.toLowerCase()}.`
+  ? `La mayor presión puntual del mes está en ${foco.dim.nombre.toLowerCase()} (${num(foco.dim.puntaje)}${foco.dim.base100 ? "" : "/100"}), la dimensión que más tensión aporta al índice de ${foco.meta.nombre.toLowerCase()}.`
   : "";
 ---
 <section class="cg-section cg-bluf" id="snapshot">

--- a/projects/informe_coyuntura/web/src/components/CinturonCard.astro
+++ b/projects/informe_coyuntura/web/src/components/CinturonCard.astro
@@ -1,5 +1,5 @@
 ---
-import { verdictDeCinturon, indicadoresOrdenados, cap, indiceDe, semaforoDimension, peorDimension } from "../lib/datos.ts";
+import { verdictDeCinturon, indicadoresOrdenados, cap, indiceDe, semaforoDimension, peorDimension, num } from "../lib/datos.ts";
 import { DIM_DESCRIPCIONES } from "../lib/descripciones.ts";
 import IndicadorRow from "./IndicadorRow.astro";
 const { slug, nombre, sub, cinturon } = Astro.props;
@@ -24,7 +24,6 @@ const pesoPct = (d: any) => Math.round((d.peso_efectivo ?? d.peso) * 100);
 // lectura rápida — el texto siempre visible responde "qué explica la
 // tensión" sin hover ni modal, y cubre también la lectura sin color).
 const peor = peorDimension(cinturon);
-const comaTxt = (n: number) => String(n).replace(".", ",");
 ---
 <article class:list={["cg-cint", `cg-cint--${slug}`]}>
   <div class="cg-cint-head">
@@ -46,16 +45,16 @@ const comaTxt = (n: number) => String(n).replace(".", ",");
               class:list={["cg-genoma-seg", `sem-${semaforoDimension(dim.puntaje, !!indice.base100)}`, "cg-dim--clickable", { "is-critica": dim.critica }]}
               data-dimension={dkey} data-cinturon={slug}
               style={`flex-grow:${pesoPct(dim)};`}
-              aria-label={`${dim.nombre}: puntaje ${dim.puntaje}, pesa ${pesoPct(dim)}% del índice — tocá para ver qué mide`}></button>
+              aria-label={`${dim.nombre}: puntaje ${num(dim.puntaje)}, pesa ${pesoPct(dim)}% del índice — tocá para ver qué mide`}></button>
             <span class="cg-genoma-tip" aria-hidden="true">
-              <span class="cg-genoma-tip-head">{dim.nombre} · <strong>{dim.puntaje}{indice.base100 ? "" : "/100"}</strong> · pesa {pesoPct(dim)}%{dim.critica ? " · dimensión crítica" : ""}</span>
+              <span class="cg-genoma-tip-head">{dim.nombre} · <strong>{num(dim.puntaje)}{indice.base100 ? "" : "/100"}</strong> · pesa {pesoPct(dim)}%{dim.critica ? " · dimensión crítica" : ""}</span>
               {DIM_DESCRIPCIONES[dkey] && <span class="cg-genoma-tip-desc">{DIM_DESCRIPCIONES[dkey]}</span>}
               <span class="cg-genoma-tip-cta">Tocá para ver la composición completa</span>
             </span>
           </>
         ))}
       </div>
-      <div class="cg-genoma-cap">{dims.length} dimensiones (ancho = peso){peor ? ` · mayor tensión: ${peor.nombre.toLowerCase()} (${comaTxt(peor.puntaje)}${peor.base100 ? "" : "/100"})` : ""} · tocá un tramo</div>
+      <div class="cg-genoma-cap">{dims.length} dimensiones (ancho = peso){peor ? ` · mayor tensión: ${peor.nombre.toLowerCase()} (${num(peor.puntaje)}${peor.base100 ? "" : "/100"})` : ""} · tocá un tramo</div>
     </>
   )}
   {!indice && (
@@ -65,7 +64,10 @@ const comaTxt = (n: number) => String(n).replace(".", ",");
     {visibles.map(({ key, ind, bucket }) => <IndicadorRow ikey={key} ind={ind} bucket={bucket} slug={slug} />)}
   </ul>
   <div class="cg-cint-foot">
-    <span>Score <strong>{cinturon.score}/10</strong> · {cap(cinturon.barbarismo_riesgo)}</span>
-    <a href={href} class="cg-cint-ver">{ocultos > 0 ? `+${ocultos} · ver detalle` : "Ver detalle"} →</a>
+    <span>Score <strong>{num(cinturon.score)}/10</strong> · {cap(cinturon.barbarismo_riesgo)}</span>
+    {/* El enlace decía "ver detalle" en minúscula cuando había ocultos y "Ver
+        detalle" cuando no: la card de espíritu de época (sin ocultos) quedaba
+        distinta de las otras cuatro. El contador va aparte del rótulo. */}
+    <a href={href} class="cg-cint-ver">{ocultos > 0 ? `+${ocultos} · ` : ""}Ver detalle →</a>
   </div>
 </article>

--- a/projects/informe_coyuntura/web/src/components/Evolucion.astro
+++ b/projects/informe_coyuntura/web/src/components/Evolucion.astro
@@ -1,5 +1,5 @@
 ---
-import { informe, CINTURONES, indiceDe, tensionDeDimension } from "../lib/datos.ts";
+import { informe, CINTURONES, indiceDe, tensionDeDimension, num } from "../lib/datos.ts";
 
 // "Cómo va la película" DE VERDAD (revisión estructural 2026-07-11): antes
 // esta sección repetía en grande 10 indicadores que ya están en las cards
@@ -11,7 +11,6 @@ import { informe, CINTURONES, indiceDe, tensionDeDimension } from "../lib/datos.
 // La reconstrucción viene de la validación externa (pares del snapshot):
 // series de componentes SIN ajustes del analista — el nivel puede diferir
 // del publicado; lo que vale es la evolución (caveat declarado abajo).
-const coma = (n: number) => String(n).replace(".", ",");
 const MES_ABREV = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
 const mesCorto = (ym: string) => `${MES_ABREV[+ym.slice(5, 7) - 1]}-${ym.slice(0, 4)}`;
 
@@ -57,13 +56,13 @@ const trayectorias = CINTURONES
                data-evo-slug={t.meta.slug} data-evo-unidad="tensión /10"
                data-evo-serie={JSON.stringify(t.serie)}></div>
           <div class="cg-chart-mini-foot">
-            <div class="cg-chart-mini-now">{coma(t.ahora)}</div>
+            <div class="cg-chart-mini-now">{num(t.ahora)}</div>
             <span class:list={["cg-chart-mini-delta", t.delta > 0 ? "up" : t.delta < 0 ? "down" : "flat"]}>
-              {t.delta > 0 ? "+" : ""}{coma(t.delta)}
+              {t.delta > 0 ? "+" : ""}{num(t.delta)}
             </span>
           </div>
           <div class="cg-sub">
-            Desde {t.desde}: <strong>{t.deltaInicio > 0 ? "+" : ""}{coma(t.deltaInicio)}</strong>
+            Desde {t.desde}: <strong>{t.deltaInicio > 0 ? "+" : ""}{num(t.deltaInicio)}</strong>
             {t.deltaInicio < 0 ? " de tensión (aflojó)" : t.deltaInicio > 0 ? " de tensión (se apretó)" : " de tensión"}
           </div>
         </div>

--- a/projects/informe_coyuntura/web/src/components/Hero.astro
+++ b/projects/informe_coyuntura/web/src/components/Hero.astro
@@ -1,5 +1,5 @@
 ---
-import { informe, cinturonesRojos, cap, mesLegible, indicadoresRezagados } from "../lib/datos.ts";
+import { informe, cinturonesRojos, cap, mesLegible, indicadoresRezagados, num } from "../lib/datos.ts";
 const rojos = cinturonesRojos(informe);
 const f = informe.generated_at;
 const datosAl = `${f.slice(8, 10)}/${f.slice(5, 7)}/${f.slice(0, 4)}`;
@@ -23,7 +23,7 @@ const rezagados = indicadoresRezagados(informe);
     <div class="cg-hero-stats">
       <div class="cg-hero-stat"><div class="cg-hero-stat-num" style="font-size:20px;">{mesLegible(informe.period)}</div><div class="cg-hero-stat-lbl">Edición</div></div>
       <div class="cg-hero-stat"><div class="cg-hero-stat-num">{rojos}</div><div class="cg-hero-stat-lbl">Cinturones en rojo</div></div>
-      <div class="cg-hero-stat"><div class="cg-hero-stat-num">{informe.score_global}</div><div class="cg-hero-stat-lbl">Score global /10</div></div>
+      <div class="cg-hero-stat"><div class="cg-hero-stat-num">{num(informe.score_global)}</div><div class="cg-hero-stat-lbl">Score global /10</div></div>
       <div class="cg-hero-stat"><div class="cg-hero-stat-num" style="font-size:20px;">{cap(informe.barbarismo_activo)}</div><div class="cg-hero-stat-lbl">Riesgo dominante</div></div>
     </div>
     <p class="cg-hero-meta">

--- a/projects/informe_coyuntura/web/src/components/IndicadorModal.astro
+++ b/projects/informe_coyuntura/web/src/components/IndicadorModal.astro
@@ -246,9 +246,21 @@ const dimsJson = JSON.stringify(dims);
   const INFO = JSON.parse(document.getElementById("cg-info-data").textContent);
   const SERIES = JSON.parse(document.getElementById("cg-series-data").textContent);
   const modal = document.getElementById("cg-modal");
-  const nf = new Intl.NumberFormat("es-AR", { maximumFractionDigits: 2 });
-  const nfPct = new Intl.NumberFormat("es-AR", { maximumFractionDigits: 1 });
+  // Mismo criterio que num() en datos.ts: coma decimal y menos TIPOGRÁFICO
+  // (U+2212), no el guion. Se envuelve el formateador en vez de tocar los ~6
+  // call-sites, y el CSV descargable no pasa por acá (usa p.valor crudo, que
+  // tiene que quedar parseable).
+  const _nf = new Intl.NumberFormat("es-AR", { maximumFractionDigits: 2 });
+  const _nfPct = new Intl.NumberFormat("es-AR", { maximumFractionDigits: 1 });
+  const nf = { format: (n) => _nf.format(n).replace("-", "−") };
+  const nfPct = { format: (n) => _nfPct.format(n).replace("-", "−") };
   const esc = (s) => String(s).replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  // La ficha mezclaba dos formatos en el MISMO campo: "jun 2026 · dato al
+  // 2026-06-01" — mes legible al lado de un ISO. El resto del sitio usa
+  // dd/mm/aaaa (ver el pie del hero), así que la fecha del dato también.
+  const fechaLegible = (iso) => /^\d{4}-\d{2}-\d{2}$/.test(iso || "")
+    ? `${iso.slice(8, 10)}/${iso.slice(5, 7)}/${iso.slice(0, 4)}`
+    : (iso || "—");
   const pctIndice = (n) => `${nfPct.format(n * 100)}%`;
   function incidenciaIndiceHtml(meta) {
     if (!meta || typeof meta.pesoEfectivo !== "number") return "";
@@ -414,8 +426,8 @@ const dimsJson = JSON.stringify(dims);
         celda("Dimensión", d.dimTxt || "—") +
         celda("Frecuencia", d.frecuencia || "—") +
         celda("Actualización", d.estado === "Automático"
-          ? `${d.periodo || "—"} · dato al ${d.fecha || "—"}`
-          : `${d.fecha || "—"} · ${d.estado}`) +
+          ? `${d.periodo || "—"} · dato al ${fechaLegible(d.fecha)}`
+          : `${fechaLegible(d.fecha)} · ${d.estado}`) +
         celda("Fuente", fuenteCorta, d.fuente);
       mostrarFormula(d.formula, d.formulaLeyenda);
 

--- a/projects/informe_coyuntura/web/src/components/Metodologia.astro
+++ b/projects/informe_coyuntura/web/src/components/Metodologia.astro
@@ -3,7 +3,7 @@
 // extracción → gates → índices → tensión), los índices paramétricos con sus
 // valores vivos, los controles de credibilidad y el acceso al diccionario de fichas.
 // TODOS los números salen del snapshot en el build — nada cargado a mano.
-import { informe, CINTURONES, indiceDe, badgeEstado, cinturonesRojos, cap } from "../lib/datos.ts";
+import { informe, CINTURONES, indiceDe, badgeEstado, cinturonesRojos, cap, num } from "../lib/datos.ts";
 import { FICHAS } from "../lib/fichas.ts";
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -46,7 +46,6 @@ const rs = indices
 
 const fase = (informe as any).ponderacion?.fase === "temprana"
   ? "fase temprana del mandato" : "fase de consolidación";
-const coma = (v: number) => String(v).replace(".", ",");
 ---
 <section class="cg-section cg-method" id="metodologia">
   <div class="cg-section-head">
@@ -82,7 +81,7 @@ const coma = (v: number) => String(v).replace(".", ",");
     </div>
     <span class="cg-met-arrow" aria-hidden="true">→</span>
     <div class="cg-met-step" role="listitem">
-      <span class="cg-met-num">{coma(informe.score_global)}<small>/10</small></span>
+      <span class="cg-met-num">{num(informe.score_global)}<small>/10</small></span>
       <span class="cg-met-lbl">Tensión global hoy</span>
       <span class="cg-met-desc">Pondera los cinco cinturones según la fase del mandato.</span>
     </div>
@@ -97,7 +96,7 @@ const coma = (v: number) => String(v).replace(".", ",");
           <span class="cg-met-ind-cint">{meta.nombre}</span>
         </div>
         <div class="cg-met-ind-val">
-          {coma(indice.data.valor)}<small>{indice.base100 ? " · base 100" : "/100"}</small>
+          {num(indice.data.valor)}<small>{indice.base100 ? " · base 100" : "/100"}</small>
         </div>
         <div class="cg-met-ind-banda">{indice.data.banda_legible}</div>
         {/* "umbrales publicados", no "institucionales": vale para los cuatro

--- a/projects/informe_coyuntura/web/src/components/Recomendaciones.astro
+++ b/projects/informe_coyuntura/web/src/components/Recomendaciones.astro
@@ -1,12 +1,11 @@
 ---
-import { informe, CINTURONES, peorDimension, indicadoresRezagados } from "../lib/datos.ts";
+import { informe, CINTURONES, peorDimension, indicadoresRezagados, num } from "../lib/datos.ts";
 
 // "Qué vigilar este mes": watchlist GENERADA del tablero (sin placeholder
 // editorial en producción, hallazgo de la revisión adversarial 2026-07-11).
 // No son recomendaciones prescriptivas — eso requiere firma editorial y se
 // suma con cada edición —: son las dimensiones que más tensión aportan hoy,
 // comparadas en tensión equivalente entre índices (bandas vs base-100).
-const coma = (n: number) => String(n).replace(".", ",");
 const candidatas = CINTURONES
   .map(m => ({ meta: m, c: informe.cinturones[m.key] }))
   .filter(x => x.c)
@@ -32,7 +31,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
           </p>
           <div class="cg-rec-meta">
             <span class:list={["cg-rec-pill", pill]}>{pillTxt}</span>
-            <span>{coma(dim.puntaje)}{dim.base100 ? "" : "/100"} · pesa {Math.round(dim.peso * 100)}% de su índice{dim.critica ? " · dimensión crítica" : ""}</span>
+            <span>{num(dim.puntaje)}{dim.base100 ? "" : "/100"} · pesa {Math.round(dim.peso * 100)}% de su índice{dim.critica ? " · dimensión crítica" : ""}</span>
           </div>
         </li>
       );

--- a/projects/informe_coyuntura/web/src/components/Sparkline.astro
+++ b/projects/informe_coyuntura/web/src/components/Sparkline.astro
@@ -2,6 +2,9 @@
 import { sparkline } from "../lib/sparkline.ts";
 import { series } from "../lib/datos.ts";
 const { indicador, estado = "verde", w = 60, h = 22 } = Astro.props;
+// La ventana de display la aplica sparkline() (ver VENTANA_SPARK): acá se pasa
+// la serie completa a propósito, para que este camino y el de IndicadorTile
+// muestren el mismo período sin tener que acordarse de recortar en los dos.
 const serie = series[indicador] ?? [];
 const sp = sparkline(serie, w, h);
 ---

--- a/projects/informe_coyuntura/web/src/lib/datos.ts
+++ b/projects/informe_coyuntura/web/src/lib/datos.ts
@@ -300,9 +300,27 @@ export function label(key: string): string {
 // Formato de valor: números con separador es-AR; strings tal cual; null → "—"
 const NF = new Intl.NumberFormat("es-AR", { maximumFractionDigits: 2 });
 const NF_COMPACT = new Intl.NumberFormat("es-AR", { notation: "compact", maximumFractionDigits: 1 });
+
+// ÚNICO formateador de números para pantalla. Antes cada componente tenía su
+// propio `coma = n => String(n).replace(".", ",")` —cinco copias— y en los
+// lugares donde el número se interpolaba crudo salía con punto: la auditoría
+// mobile del 29-jul-2026 encontró el MISMO valor escrito de las dos formas en
+// una sola página (`3,2` en la bajada y `3.2` en la card del hero, `47,4` y
+// `47.4`, `96.7/100` junto a `96,7`), y `/metodologia/` con punto en todo.
+// Dos reglas, las dos son convención del proyecto:
+//   · separador decimal es-AR (coma)
+//   · menos tipográfico U+2212, no el guion U+002D — igual que las unidades y
+//     las anclas que escribe el pipeline (ver politica.py)
+// NO usar para el CSV descargable ni para valores que van a `style`/`width`:
+// ahí el número tiene que quedar parseable.
+export function num(valor: number | null | undefined): string {
+  if (valor === null || valor === undefined || Number.isNaN(valor)) return "—";
+  return NF.format(valor).replace("-", "−");
+}
+
 export function formatValor(valor: unknown): string {
   if (valor === null || valor === undefined) return "—";
-  if (typeof valor === "number") return NF.format(valor);
+  if (typeof valor === "number") return num(valor);
   return String(valor);
 }
 

--- a/projects/informe_coyuntura/web/src/lib/fichas.ts
+++ b/projects/informe_coyuntura/web/src/lib/fichas.ts
@@ -2307,7 +2307,7 @@ export const FICHAS: Record<string, Ficha> = {
       "El componente del índice mide el encarecimiento RELATIVO de la comida: el nivel de alimentos contra el nivel general de precios, rebaseado a 100 = 4º trimestre de 2023. Por encima de 100, la comida sube menos que el resto de los precios.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de presión de precios (40% interno · 10% del ITVC).",
+      "Pertenece a la dimensión de presión de precios (35% interno · 8,75% del ITVC).",
       "La comparación contra el IPC general evita contar dos veces el ratio salario/comida, que ya mide la brecha con la canasta.",
     ],
     limitaciones: [
@@ -2404,13 +2404,15 @@ export const FICHAS: Record<string, Ficha> = {
       "No se invierte: un índice líder más alto anticipa mejor actividad, que es mejora.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de prospectivas de empleo (20% interno · 3% del ITVC).",
+      "Pertenece a la dimensión de prospectivas de empleo (13% interno · 1,95% del ITVC).",
       "Es el único componente del cinturón que mira hacia adelante. Los otros tres de su dimensión describen lo ya ocurrido: la actividad industrial y la construcción son contemporáneas, y la subocupación llega con dos trimestres de rezago.",
     ],
     limitaciones: [
       "Anticipa el ciclo económico, no el humor de los hogares: un giro del índice señala hacia dónde va la actividad, no cómo la están viviendo las familias.",
       "Como todo índice líder, da señales falsas: puede moverse sin que el giro llegue a producirse.",
       "Es un compuesto y no publica el detalle mensual de qué componente lo movió.",
+      "El NIVEL no es comparable entre décadas: la serie deriva hacia arriba a lo largo de su historia —promedia 79,9 entre 1993 y 2001 contra 133,8 entre 2008 y 2015—, así que ubicar el valor de hoy en un percentil de los treinta y tres años compararía regímenes distintos del mismo índice. Por eso el cinturón puntúa el índice rebaseado al cuarto trimestre de 2023 y no el nivel.",
+      "Referencias de la serie completa (1993-2026), para leer el nivel con escala: máximo 150,4 en febrero de 2018 y mínimo 64,5 en noviembre de 2001.",
     ],
     faltantes: "Se mantiene el último valor publicado como desactualizado; sin componente, renormalización.",
     revisiones: "La UTDT puede revisar meses previos al recalcular el compuesto; se re-descarga la serie completa en cada corrida.",
@@ -2468,7 +2470,7 @@ export const FICHAS: Record<string, Ficha> = {
       "El componente mide el peso de los servicios regulados en el salario: nivel de regulados contra nivel del RIPTE, rebaseado a 100 = 4º trimestre de 2023. Por debajo de 100, las tarifas subieron más que los salarios desde el arranque.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de presión de precios (60% interno · 15% del ITVC).",
+      "Pertenece a la dimensión de presión de precios (45% interno · 11,25% del ITVC).",
       "Captura el efecto de la quita de subsidios que el IPC general diluye.",
     ],
     limitaciones: [
@@ -2498,7 +2500,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Componente del índice: el consumo rebaseado a 100 = promedio del 4º trimestre de 2023 (menos carne = deterioro).",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de confianza y seguridad (10% interno · 1,5% del ITVC).",
+      "Pertenece a la dimensión de ingresos y consumo (4% interno · 1,5% del ITVC).",
     ],
     limitaciones: [
       "Consumo «aparente» (producción menos exportaciones), no medición de hogares. No capta la sustitución hacia proteína más barata, que en este período fue grande: entre diciembre de 2023 y hoy el consumo de carne vacuna cayó un 10%, pero el de cerdo subió un 12% y el de pollo se mantuvo, de modo que el consumo total de las tres carnes cayó apenas un 3%. Como termómetro de TENDENCIA sigue siendo válido —la carne vacuna se mueve casi igual que el total de las tres (correlación 0,99 en los cambios mes a mes)—, pero leído como NIVEL de bienestar alimentario exagera el deterioro. Por eso pesa poco (1,5%) y acompaña, no lidera.",
@@ -2529,7 +2531,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Componente del índice: la tasa rebaseada de forma invertida (menos informalidad = mejora) contra el trimestre del arranque del mandato (4º trimestre de 2023).",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de sostenibilidad de ingresos (35% interno · 12,25% del ITVC).",
+      "Pertenece a la dimensión de ingresos y consumo (32,9% interno · 12,25% del ITVC).",
     ],
     limitaciones: [
       "Solo asalariados: no captura la informalidad cuentapropista.",
@@ -2561,7 +2563,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Se usa la serie desestacionalizada porque la original mostraba variaciones de hasta ±20% mensual de puro calendario.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de prospectivas de empleo (45% interno · 6,75% del ITVC).",
+      "Pertenece a la dimensión de prospectivas de empleo (23% interno · 3,45% del ITVC).",
     ],
     limitaciones: [
       "Es una aproximación declarada: mide producción industrial agregada, no mortandad de empresas — el nombre del indicador promete más de lo que la fuente da.",
@@ -2591,7 +2593,7 @@ export const FICHAS: Record<string, Ficha> = {
       "La serie original tiene un desplome estacional en diciembre que contaminaría la base: por eso la desestacionalizada.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de prospectivas de empleo (40% interno · 6% del ITVC).",
+      "Pertenece a la dimensión de prospectivas de empleo (21% interno · 3,15% del ITVC).",
     ],
     limitaciones: [
       "Aproximación al empleo vía actividad de la construcción, no despachos de cemento reales (la serie de insumos existe aparte, como contraste).",
@@ -2619,7 +2621,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Componente del índice: la tasa rebaseada de forma invertida (menos subocupación demandante = mejora) contra el 4º trimestre de 2023.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de prospectivas de empleo (15% interno · 2,25% del ITVC).",
+      "Pertenece a la dimensión de prospectivas de empleo (8% interno · 1,2% del ITVC).",
     ],
     limitaciones: [
       "Aproximación declarada: mide gente que trabaja poco y busca más, no la tenencia de múltiples empleos.",
@@ -2649,7 +2651,7 @@ export const FICHAS: Record<string, Ficha> = {
       "La ventana de 12 meses de la pregunta desestacionaliza por construcción.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de confianza y seguridad (30% interno · 4,5% del ITVC).",
+      "Es el único indicador de la dimensión de seguridad, así que se lleva su peso entero: 4,5% del ITVC.",
     ],
     limitaciones: [
       "La encuesta estuvo suspendida entre 2020 y 2023: la base de enero de 2024 es una aproximación declarada del arranque (su ventana de 12 meses cubre mayormente el año previo).",
@@ -2679,7 +2681,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Componente del índice: el ICC rebaseado a 100 = promedio del 4º trimestre de 2023 (más confianza = mejora).",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de confianza y seguridad (45% interno · 6,75% del ITVC).",
+      "Pertenece a la dimensión de confianza y percepción (81,8% interno · 6,75% del ITVC).",
     ],
     dobleUso: "Doble función declarada: (1) componente del ITVC; (2) ancla de la validación externa del ITVC — para no ser circular, en ese estudio el índice se recalcula sin este componente. Hasta julio de 2026 puntuó además en el cinturón espíritu de época, que desde entonces quedó acotado a la intención migratoria; esa lectura se sigue registrando como seguimiento interno.",
     limitaciones: [
@@ -2710,7 +2712,7 @@ export const FICHAS: Record<string, Ficha> = {
       "El cociente entre valores de una misma consulta cancela la renormalización de escala de la fuente.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de confianza y seguridad (10% interno · 1,5% del ITVC): peso chico acorde a un constructo blando.",
+      "Pertenece a la dimensión de confianza y percepción (18,2% interno · 1,5% del ITVC): peso chico acorde a un constructo blando.",
       "La card muestra el pulso de tres meses; el puntaje usa la canasta mensual de ventana fija — doble registro declarado.",
     ],
     dobleUso: "Hasta julio de 2026 integró además el cinturón espíritu de época con fórmula de tensión propia; ese cinturón quedó acotado a la intención migratoria y la lectura duplicada se sigue registrando como seguimiento interno, sin publicarse ni puntuar.",
@@ -2744,7 +2746,7 @@ export const FICHAS: Record<string, Ficha> = {
       "Recorte declarado: el componente se acota al techo de 140 — un boom puntual no compra compensación ilimitada dentro del índice; el valor crudo queda declarado en el detalle.",
     ],
     incidenciaTexto: [
-      "Pertenece a la dimensión de confianza y seguridad (5% interno · 0,75% del ITVC): el peso más chico del índice.",
+      "Pertenece a la dimensión de ingresos y consumo (2% interno · 0,75% del ITVC): el peso más chico del índice.",
     ],
     limitaciones: [
       "Es el componente más eufórico del cinturón (muy por encima de su base): motivo del techo de recorte y de la baja de peso.",

--- a/projects/informe_coyuntura/web/src/lib/sparkline.ts
+++ b/projects/informe_coyuntura/web/src/lib/sparkline.ts
@@ -8,9 +8,31 @@ export interface SparkPaths {
   vacio: boolean;
 }
 
+// Tope de puntos que dibuja una sparkline de lista. Antes se pasaba la serie
+// COMPLETA a 60x22px, así que las más largas comprimían ocho años en 60 píxeles
+// (brecha_obra_publica tiene 100 puntos contra una mediana de 32 por card) y dos
+// filas del mismo ancho podían cubrir períodos muy distintos sin que nada lo
+// indicara.
+//
+// No iguala los períodos —eso exigiría recortar todas al largo de la más corta—
+// sino que ACOTA los casos extremos: ninguna card comprime más de cuatro años.
+//
+// Va acá y no en un componente porque hay DOS caminos de render: las filas de la
+// home (Sparkline.astro) y las tiles de las páginas de cinturón
+// (IndicadorTile.astro, que llama a esta función directo). Puesto en uno solo,
+// el mismo indicador quedaba con 48 puntos en un lado y 100 en el otro.
+//
+// No recorta el DATO: el gráfico del modal usa ApexCharts, y su tabla y su CSV
+// descargable siguen con la serie entera.
+//
+// Al 29-jul-2026 ninguna card renderiza más de 33 puntos, así que esto todavía
+// no cambia nada visible: entra a jugar cuando el cron publique las series que
+// se registraron el mismo día (`alquiler_real` 59 puntos, `indice_lider` 60).
+export const VENTANA_SPARK = 48;
+
 // w/h en unidades de viewBox; pad vertical para que la línea no toque los bordes.
 export function sparkline(serie: PuntoSerie[], w = 60, h = 22, pad = 3): SparkPaths {
-  const vals = serie.map(p => p.valor);
+  const vals = serie.slice(-VENTANA_SPARK).map(p => p.valor);
   if (vals.length < 2) return { linea: "", area: "", ultimo: null, vacio: true };
   const min = Math.min(...vals), max = Math.max(...vals);
   const span = max - min || 1;

--- a/projects/informe_coyuntura/web/src/pages/[slug].astro
+++ b/projects/informe_coyuntura/web/src/pages/[slug].astro
@@ -6,7 +6,7 @@ import IndicadorTile from "../components/IndicadorTile.astro";
 import IndicadorModal from "../components/IndicadorModal.astro";
 import {
   informe, CINTURONES, verdictDeCinturon, indicadoresOrdenados,
-  fuentesDeCinturon, cap, indiceDe, label,
+  fuentesDeCinturon, cap, indiceDe, label, num,
 } from "../lib/datos.ts";
 
 export function getStaticPaths() {
@@ -63,7 +63,6 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 // área suave en el color del cinturón, franja p05-p95 resaltada, línea del
 // valor publicado y — para índices base-100 — la línea de referencia del 100.
 const rob = indice?.data.robustez ?? null;
-const coma = (v: number) => String(v).replace(".", ",");
 let robSvg: {
   W: number; H: number; base: number; area: string; line: string;
   x05: number; x95: number; xval: number; x100: number | null;
@@ -208,8 +207,8 @@ const robChartData = rob?.hist && indice ? {
       <p class="cg-hero-lead cg-detalle-lead">{meta.sub}.</p>
       <div class="cg-detalle-meta">
         <span class:list={["cg-verdict", verdict]}><span class="cg-verdict-dot"></span>{verdictLabel}</span>
-        <span class="cg-detalle-chip">Score <strong>{c.score}/10</strong></span>
-        {indice && <span class="cg-detalle-chip">{indice.sigla} <strong>{indice.data.valor}{indice.base100 ? "" : "/100"}</strong> · {indice.data.banda_legible}</span>}
+        <span class="cg-detalle-chip">Score <strong>{num(c.score)}/10</strong></span>
+        {indice && <span class="cg-detalle-chip">{indice.sigla} <strong>{num(indice.data.valor as number)}{indice.base100 ? "" : "/100"}</strong> · {indice.data.banda_legible}</span>}
         <span class="cg-detalle-chip">Riesgo: <strong>{cap(c.barbarismo_riesgo)}</strong></span>
         <span class="cg-detalle-chip">{filas.length} {filas.length === 1 ? "indicador" : "indicadores"}</span>
       </div>
@@ -220,7 +219,7 @@ const robChartData = rob?.hist && indice ? {
       <section class="cg-section">
         <div class="cg-section-head">
           <p class="cg-eyebrow">Índice paramétrico</p>
-          <h2 class="cg-h2">{indice.sigla}: {indice.data.valor}{indice.base100 ? " (base 100 = 4T-2023)" : "/100"} — {indice.data.banda_legible}</h2>
+          <h2 class="cg-h2">{indice.sigla}: {num(indice.data.valor as number)}{indice.base100 ? " (base 100 = 4T-2023)" : "/100"} — {indice.data.banda_legible}</h2>
           <p class="cg-h2-sub">{indice.descripcion}</p>
         </div>
         <div class="cg-itcm-dims">
@@ -230,9 +229,9 @@ const robChartData = rob?.hist && indice ? {
                  role="button" tabindex="0" aria-label={`Ver la composición de ${dim.nombre}`}>
               <div class="cg-itcm-dim-head">
                 <span class="cg-itcm-dim-name">{dim.nombre}</span>
-                <span class="cg-itcm-dim-val"><strong>{dim.puntaje}</strong>{indice.base100 ? "" : "/100"} · pesa {Math.round(dim.peso * 100)}%</span>
+                <span class="cg-itcm-dim-val"><strong>{num(dim.puntaje)}</strong>{indice.base100 ? "" : "/100"} · pesa {Math.round(dim.peso * 100)}%</span>
               </div>
-              <div class="cg-bar" role="img" aria-label={`${dim.puntaje} de 100`}>
+              <div class="cg-bar" role="img" aria-label={`${num(dim.puntaje)} de 100`}>
                 <div class="cg-bar-fill" style={`width:${Math.min(100, dim.puntaje)}%`}></div>
               </div>
               {dim.critica && (
@@ -270,7 +269,7 @@ const robChartData = rob?.hist && indice ? {
               <div class="cg-dim-group-head">
                 <h3 class="cg-dim-group-name">{g.nombre}</h3>
                 <span class="cg-dim-group-meta">
-                  <strong>{g.puntaje}</strong>{indice!.base100 ? "" : "/100"} · pesa {Math.round(g.peso * 100)}% · {g.filas.filter(f => !f.ind.cumplido).length} {g.filas.filter(f => !f.ind.cumplido).length === 1 ? "indicador" : "indicadores"}{g.filas.some(f => f.ind.cumplido) && ` + ${g.filas.filter(f => f.ind.cumplido).length} logrado`}
+                  <strong>{num(g.puntaje)}</strong>{indice!.base100 ? "" : "/100"} · pesa {Math.round(g.peso * 100)}% · {g.filas.filter(f => !f.ind.cumplido).length} {g.filas.filter(f => !f.ind.cumplido).length === 1 ? "indicador" : "indicadores"}{g.filas.some(f => f.ind.cumplido) && ` + ${g.filas.filter(f => f.ind.cumplido).length} logrado`}
                 </span>
               </div>
               <div class="cg-tile-grid">
@@ -332,10 +331,10 @@ const robChartData = rob?.hist && indice ? {
              aria-label="Ver el detalle del análisis de robustez">
           <div class="cg-rob-head">
             <span>Distribución simulada del {indice.sigla}</span>
-            <span>90% de los casos: <strong>{coma(rob.p05)} – {coma(rob.p95)}</strong></span>
+            <span>90% de los casos: <strong>{num(rob.p05)} – {num(rob.p95)}</strong></span>
           </div>
           <svg class="cg-rob-svg" viewBox={`0 0 ${robSvg.W} ${robSvg.H}`} role="img"
-               aria-label={`Distribución simulada del ${indice.sigla}: entre ${coma(rob.p05)} y ${coma(rob.p95)} en el 90% de los escenarios`}>
+               aria-label={`Distribución simulada del ${indice.sigla}: entre ${num(rob.p05)} y ${num(rob.p95)} en el 90% de los escenarios`}>
             <defs>
               <clipPath id="rob-clip">
                 <rect x={robSvg.x05} y="0" width={robSvg.x95 - robSvg.x05} height={robSvg.H} />
@@ -355,17 +354,17 @@ const robChartData = rob?.hist && indice ? {
                   stroke="var(--bd)" stroke-width="1" />
           </svg>
           <div class="cg-rob-ticks">
-            <span class="cg-rob-tick" style={`left:${robSvg.pct(robSvg.x05)}%`}>{coma(rob.p05)}</span>
-            <span class="cg-rob-tick cg-rob-tick--val" style={`left:${robSvg.pct(robSvg.xval)}%`}>{coma(indice.data.valor)}</span>
-            <span class="cg-rob-tick" style={`left:${robSvg.pct(robSvg.x95)}%`}>{coma(rob.p95)}</span>
+            <span class="cg-rob-tick" style={`left:${robSvg.pct(robSvg.x05)}%`}>{num(rob.p05)}</span>
+            <span class="cg-rob-tick cg-rob-tick--val" style={`left:${robSvg.pct(robSvg.xval)}%`}>{num(indice.data.valor)}</span>
+            <span class="cg-rob-tick" style={`left:${robSvg.pct(robSvg.x95)}%`}>{num(rob.p95)}</span>
             {robSvg.x100 !== null && (
               <span class="cg-rob-tick cg-rob-tick--ext" style={`left:${robSvg.pct(robSvg.x100)}%`}>100 = 4T-23</span>
             )}
           </div>
           <p class="cg-h2-sub">
-            El {indice.sigla} queda entre <strong>{coma(rob.p05)}</strong> y{" "}
-            <strong>{coma(rob.p95)}</strong> en el 90% de los casos (tensión{" "}
-            {coma(rob.tension_rango[0])}–{coma(rob.tension_rango[1])}): la lectura del
+            El {indice.sigla} queda entre <strong>{num(rob.p05)}</strong> y{" "}
+            <strong>{num(rob.p95)}</strong> en el 90% de los casos (tensión{" "}
+            {num(rob.tension_rango[0])}–{num(rob.tension_rango[1])}): la lectura del
             cinturón no depende de la ponderación exacta ni del error de medición de las fuentes.
             {robBajoBase && (
               <Fragment>
@@ -387,7 +386,7 @@ const robChartData = rob?.hist && indice ? {
                  aria-label="Ver el detalle de la validación externa">
               <div class="cg-rob-head">
                 <span>El {indice.sigla} y su contraste externo, mes a mes</span>
-                <span>correlación <strong>{coma(val.r_niveles)}</strong> · {val.n} meses</span>
+                <span>correlación <strong>{num(val.r_niveles)}</strong> · {val.n} meses</span>
               </div>
               <svg class="cg-rob-svg" viewBox={`0 0 ${valSvg.W} ${valSvg.H}`} role="img"
                    aria-label={`Evolución comparada: ${val.serie_label} y ${val.externa_label}`}>
@@ -448,7 +447,7 @@ const robChartData = rob?.hist && indice ? {
                       {cruz.externas.map(e => (
                         // sin espacios entre el número y el span: el salto de línea
                         // quedaba como espacio final y descentraba el número ~6px
-                        <td class:list={[f.propio === e[0] && "es-propio"]}>{(f[e[0]].r > 0 ? "+" : "") + coma(f[e[0]].r)}<span class="cg-cruz-n">{typeof f[e[0]].rd === "number" ? `Δ ${(f[e[0]].rd > 0 ? "+" : "") + coma(f[e[0]].rd)} · ` : ""}{f[e[0]].n} meses</span></td>
+                        <td class:list={[f.propio === e[0] && "es-propio"]}>{(f[e[0]].r > 0 ? "+" : "") + num(f[e[0]].r)}<span class="cg-cruz-n">{typeof f[e[0]].rd === "number" ? `Δ ${(f[e[0]].rd > 0 ? "+" : "") + num(f[e[0]].rd)} · ` : ""}{f[e[0]].n} meses</span></td>
                       ))}
                     </tr>
                   ))}
@@ -476,7 +475,7 @@ const robChartData = rob?.hist && indice ? {
             <div class={`cg-rob cg-rob--${meta.slug} cg-red`}>
               <div class="cg-red-stats">
                 <div class="cg-red-stat">
-                  <span class="cg-red-num">{coma(red.r_abs_medio)}</span>
+                  <span class="cg-red-num">{num(red.r_abs_medio)}</span>
                   <span class="cg-red-lbl">correlación media entre pares</span>
                 </div>
                 <div class="cg-red-stat">
@@ -489,7 +488,7 @@ const robChartData = rob?.hist && indice ? {
                 </div>
                 {red.diferencias?.r_abs_medio != null && (
                   <div class="cg-red-stat cg-red-stat--clave">
-                    <span class="cg-red-num">{coma(red.diferencias.r_abs_medio)}</span>
+                    <span class="cg-red-num">{num(red.diferencias.r_abs_medio)}</span>
                     <span class="cg-red-lbl">al mirar los cambios mes a mes<br/>—sin la tendencia común—</span>
                   </div>
                 )}
@@ -528,7 +527,7 @@ const robChartData = rob?.hist && indice ? {
             </div>
             <div class={`cg-rob cg-rob--${meta.slug} cg-rez`}>
               <div class="cg-rez-hero">
-                <span class="cg-rez-num">{coma(rez.promedio_meses)}</span>
+                <span class="cg-rez-num">{num(rez.promedio_meses)}</span>
                 <span class="cg-rez-unidad">meses</span>
                 <span class="cg-rez-lbl">de antigüedad promedio de la foto,<br/>ponderada por el peso de cada indicador</span>
               </div>
@@ -550,7 +549,7 @@ const robChartData = rob?.hist && indice ? {
                     {rez.mas_rezagados.map((m: any) => (
                       <li>
                         <span class="cg-rez-ind">{label(m.indicador)}</span>
-                        <span class="cg-rez-meses">≈ {coma(m.meses)} meses</span>
+                        <span class="cg-rez-meses">≈ {num(m.meses)} meses</span>
                       </li>
                     ))}
                   </ul>
@@ -569,7 +568,7 @@ const robChartData = rob?.hist && indice ? {
             </div>
             <div class={`cg-rob cg-rob--${meta.slug} cg-rez cg-lb`}>
               <div class="cg-rez-hero">
-                <span class="cg-rez-num">{lb.brecha >= 0 ? "+" : "−"}{coma(Math.abs(lb.brecha))}</span>
+                <span class="cg-rez-num">{lb.brecha >= 0 ? "+" : "−"}{num(Math.abs(lb.brecha))}</span>
                 <span class="cg-rez-unidad">puntos</span>
                 <span class="cg-rez-lbl">de distancia entre el índice de hoy<br/>y el del mes del traspaso</span>
               </div>
@@ -577,11 +576,11 @@ const robChartData = rob?.hist && indice ? {
               <ul class="cg-lb-par">
                 <li>
                   <span class="cg-lb-ym">Diciembre 2023</span>
-                  <span class="cg-lb-val">{coma(lb.valor)}</span>
+                  <span class="cg-lb-val">{num(lb.valor)}</span>
                 </li>
                 <li>
                   <span class="cg-lb-ym">Hoy</span>
-                  <span class="cg-lb-val cg-lb-val--hoy">{coma(Math.round((indice!.data.valor as number) * 10) / 10)}</span>
+                  <span class="cg-lb-val cg-lb-val--hoy">{num(Math.round((indice!.data.valor as number) * 10) / 10)}</span>
                 </li>
               </ul>
               <p class="cg-h2-sub">{lb.conclusion}</p>
@@ -631,7 +630,7 @@ const robChartData = rob?.hist && indice ? {
             <div class={`cg-rob cg-rob--${meta.slug} cg-vin`}>
               <div class="cg-vin-hero">
                 <div class="cg-vin-dato">
-                  <span class="cg-vin-num">{coma(vin.meses_promedio)}</span>
+                  <span class="cg-vin-num">{num(vin.meses_promedio)}</span>
                   <span class="cg-vin-lbl">meses de antigüedad<br/>media del dato</span>
                 </div>
                 <div class="cg-vin-dato">
@@ -650,7 +649,7 @@ const robChartData = rob?.hist && indice ? {
                     {vin.rezagados.map((r: any) => (
                       <li>
                         <span class="cg-vin-ind">{label(r.indicador)}</span>
-                        <span class="cg-vin-meses">{r.fecha} · {coma(r.meses)} meses</span>
+                        <span class="cg-vin-meses">{r.fecha} · {num(r.meses)} meses</span>
                       </li>
                     ))}
                   </ul>
@@ -686,7 +685,7 @@ const robChartData = rob?.hist && indice ? {
           victimización (LICIP-UTDT) con base en enero de 2024 — la encuesta estuvo suspendida
           entre 2020 y 2023 y no existe medición del 4º trimestre de 2023; el registro de
           denuncias (SNIC) queda como contraste. El{" "}
-          <strong>score {c.score}/10</strong> deriva del <strong>ITVC {c.itvc?.valor}</strong>:
+          <strong>score {num(c.score)}/10</strong> deriva del <strong>ITVC {num(c.itvc?.valor)}</strong>:
           tensión = 5 − (ITVC − 100) × 0,2.
         </p>
       </section>
@@ -712,8 +711,8 @@ const robChartData = rob?.hist && indice ? {
           <strong>asistencia directa</strong> mide la desintermediación del gasto social (TDPS) y
           el <strong>orden público</strong>, la reducción de cortes en CABA vs. 2023 — con su
           validez judicial restablecida: la Cámara revocó en marzo de 2026 la nulidad de primera
-          instancia. El <strong>score {c.score}/10</strong> y el{" "}
-          <strong>ITCG {c.itcg?.valor}/100</strong> son la misma medición en dos escalas:
+          instancia. El <strong>score {num(c.score)}/10</strong> y el{" "}
+          <strong>ITCG {num(c.itcg?.valor)}/100</strong> son la misma medición en dos escalas:
           tensión = (100 − ITCG) / 10.
         </p>
       </section>
@@ -744,8 +743,8 @@ const robChartData = rob?.hist && indice ? {
           sus umbrales se calibraron a la volatilidad real de las series, no al ±2% teórico.
           Cada indicador se puntúa por <strong>interpolación entre las anclas</strong> de su
           tabla de umbrales (sin escalones de banda: dos valores casi iguales reciben
-          puntajes casi iguales). El <strong>score {c.score}/10</strong> y
-          el <strong>ITCM {c.itcm?.valor}/100</strong> son la misma medición en dos escalas:
+          puntajes casi iguales). El <strong>score {num(c.score)}/10</strong> y
+          el <strong>ITCM {num(c.itcm?.valor)}/100</strong> son la misma medición en dos escalas:
           tensión = (100 − ITCM) / 10; la escala 0–10 permite comparar macro con los otros
           cuatro cinturones y componer el score global.
         </p>
@@ -778,10 +777,10 @@ const robChartData = rob?.hist && indice ? {
         puede mover un puntaje). El ejercicio es reproducible: el azar parte siempre del mismo punto.
       </p>
       <dl class="cg-modal-ficha">
-        <div><dt>Valor publicado</dt><dd>{coma(indice.data.valor)}</dd></div>
-        <div><dt>90% de los casos</dt><dd>{coma(rob.p05)} – {coma(rob.p95)}</dd></div>
-        <div><dt>Amplitud</dt><dd>{coma(robAmplitud!)} puntos</dd></div>
-        <div><dt>En tensión (0-10)</dt><dd>{coma(rob.tension_rango[0])} – {coma(rob.tension_rango[1])}</dd></div>
+        <div><dt>Valor publicado</dt><dd>{num(indice.data.valor)}</dd></div>
+        <div><dt>90% de los casos</dt><dd>{num(rob.p05)} – {num(rob.p95)}</dd></div>
+        <div><dt>Amplitud</dt><dd>{num(robAmplitud!)} puntos</dd></div>
+        <div><dt>En tensión (0-10)</dt><dd>{num(rob.tension_rango[0])} – {num(rob.tension_rango[1])}</dd></div>
       </dl>
       <p class="cg-modal-h4">La distribución de los {rob.n_draws.toLocaleString("es-AR")} escenarios</p>
       <div id="cg-det-rob-chart" data-sigla={indice.sigla}></div>
@@ -795,8 +794,8 @@ const robChartData = rob?.hist && indice ? {
           <p class="cg-modal-desc">
             <strong>{domLabel}</strong> es el indicador que más arrastra el resultado: si se
             lo quitara del índice (repartiendo su peso entre los demás), el {indice.sigla}{" "}
-            sería <strong>{coma(rob.dominante.indice_sin)}</strong> —{" "}
-            {domDelta! > 0 ? "una mejora" : "un deterioro"} de {coma(Math.abs(domDelta!))} puntos.
+            sería <strong>{num(rob.dominante.indice_sin)}</strong> —{" "}
+            {domDelta! > 0 ? "una mejora" : "un deterioro"} de {num(Math.abs(domDelta!))} puntos.
             Que un solo componente explique una diferencia así no invalida el índice, pero es
             la señal a vigilar: su dato manda sobre la lectura del mes.
           </p>
@@ -823,8 +822,8 @@ const robChartData = rob?.hist && indice ? {
         juntas — sin ser idénticas.
       </p>
       <dl class="cg-modal-ficha">
-        <div><dt>Correlación (niveles)</dt><dd>{coma(val.r_niveles)}</dd></div>
-        <div><dt>Cambios mes a mes</dt><dd>{coma(val.r_diferencias)}</dd></div>
+        <div><dt>Correlación (niveles)</dt><dd>{num(val.r_niveles)}</dd></div>
+        <div><dt>Cambios mes a mes</dt><dd>{num(val.r_diferencias)}</dd></div>
         <div><dt>Muestra</dt><dd>{val.n} meses</dd></div>
       </dl>
       <p class="cg-modal-h4">Las dos series, en sus valores reales</p>

--- a/projects/informe_coyuntura/web/src/pages/metodologia/index.astro
+++ b/projects/informe_coyuntura/web/src/pages/metodologia/index.astro
@@ -5,7 +5,7 @@
 import Layout from "../../layouts/Layout.astro";
 import Nav from "../../components/Nav.astro";
 import Footer from "../../components/Footer.astro";
-import { informe, CINTURONES, label, badgeEstado, indiceDe, indicadoresOrdenados, mesLegible } from "../../lib/datos.ts";
+import { informe, CINTURONES, label, badgeEstado, indiceDe, indicadoresOrdenados, mesLegible, num } from "../../lib/datos.ts";
 import { DESCRIPCIONES } from "../../lib/descripciones.ts";
 import { FICHAS } from "../../lib/fichas.ts";
 
@@ -75,7 +75,7 @@ const totalFichas = Object.keys(FICHAS).length;
             <Row class:list={["cg-dicc-row", { "is-pend": !tieneFicha }]} href={tieneFicha ? href : undefined}>
               <div class="cg-dicc-main">
                 <span class="cg-dicc-name">{indice!.sigla} — {indice!.nombre}</span>
-                <span class="cg-dicc-que">Cinturón {meta.nombre.toLowerCase()} · hoy {indice!.data.valor}{indice!.base100 ? "" : "/100"} · {indice!.data.banda_legible}</span>
+                <span class="cg-dicc-que">Cinturón {meta.nombre.toLowerCase()} · hoy {num(indice!.data.valor as number)}{indice!.base100 ? "" : "/100"} · {indice!.data.banda_legible}</span>
               </div>
               <div class="cg-dicc-chips">
                 <span class="cg-dicc-chip">Índice compuesto</span>


### PR DESCRIPTION
Auditoría a **390×844 con emulación mobile real** (Chrome headless propio, por CDP) sobre las 7 rutas del sitio. Todo lo que sigue está verificado contra el build local, no deducido del código.

Dos commits: los arreglos de UI y, después, las dos series sin backfill que aparecieron tirando del hilo de un síntoma visual.

## Un solo formateador de números

Había **cinco copias** de `coma = n => String(n).replace(".", ",")` en los componentes, y donde el número se interpolaba crudo salía con punto. El resultado era el **mismo valor escrito de dos formas en una sola página**:

| ruta | valores duplicados |
|---|---|
| `/` | `3.2` `47.4` `40.4` `78.6` `6.1` `58.2` |
| `/politica/` | `64.3` `96.7` `48.9` `52.4` |
| `/vida/` | `94.4` |
| `/gestion/` | `77.8` |

`/metodologia/` —lo más institucional del sitio— usaba punto en todo: 4 decimales con punto, 0 con coma.

Ahora hay un solo `num()` en `datos.ts` con las dos convenciones del proyecto: coma decimal es-AR y **menos tipográfico U+2212**. El CSV descargable y los valores que van a `style`/`width` no pasan por ahí, porque tienen que quedar parseables.

En el pipeline pasaba lo mismo: **trece copias** del mismo lambda en `publicar.py`, ninguna con el signo menos, y por eso las conclusiones de validación decían «ITCM -0,84 con el riesgo país». Un solo `coma()` a nivel módulo que convierte **sólo el menos inicial** — el guion de `2026-06-01` o `1997-2026` no es un signo menos.

## Dos casos de CSS muerto

**El 2×2 del hero en mobile estaba escrito pero nunca corrió.** El contenedor es `flex` y las dos reglas seteaban `grid-template-columns`, que flex ignora. Las 4 cards caían una por fila y se comían una pantalla entera para cuatro datos. Ahora es grid de verdad: **2 filas en vez de 4**, verificado sin desborde a 390px.

**El único scroll horizontal del sitio**, en `/gestion/`: `scrollWidth` 395 contra viewport 390. El culpable es un `li` con `space-between` donde `.cg-vin-meses` lleva `white-space: nowrap` y la fecha larga («31 de diciembre de 2025 · 6,9 meses») no puede encogerse ni cortarse. Se apila en angosto en vez de sacarle el `nowrap`, que es lo que protege que la fecha no se parta.

## Área táctil y legibilidad

- **Los tramos de la barra de dimensiones miden 9px de alto** y el pie de la barra invita a «tocá un tramo». Área táctil a **45px** con un `::after`, sin mover un pixel del diseño ni del layout, y sólo en punteros gruesos.
- **Descripciones de las tiles cortadas a 2 líneas**: en una columna son ~10 palabras y la frase queda cortada donde empezaba a informar («…(23 provincias y la Ciudad de Buenos Aires) figuran…»). 4 líneas en angosto; sigue acotado.
- **«ver detalle» vs «Ver detalle»**: minúscula cuando había indicadores ocultos y mayúscula cuando no, así que la card de espíritu de época quedaba distinta de las otras cuatro.
- **La ficha del modal mezclaba dos formatos** en el mismo campo: `jun 2026 · dato al 2026-06-01`. La fecha del dato va en dd/mm/aaaa como el resto del sitio.

## Dos series sin backfill, encontradas por un síntoma visual

De las 25 filas de indicador de la home, `alquiler_real` era **la única sin sparkline**. No era un problema de front: su serie tenía **un punto** —el valor del día— cuando la regla del proyecto pide backfill desde dic-2023. Al medir el invariante apareció un segundo caso idéntico: **`indice_lider`**, que además puntúa (13% de la dimensión empleo del ITVC).

Los dos tenían un pariente con historia (`itvc_alquiler`, `itvc_lider`, 33 puntos cada uno) y ahí estaba la trampa: parecía que la serie ya existía. Pero esos son los componentes **rebaseados** del ITVC (100 = 4T-2023) y las cards publican otra cosa —variación mensual y nivel—, así que no son intercambiables.

- `alquiler_real`: **59 puntos** (ago-2021 → jun-2026), derivado del nivel con `_var_mensual`, que exige meses consecutivos.
- `indice_lider`: **60 puntos** (jul-2021 → jun-2026). El XLS de la UTDT arranca en 1993 y son 402 puntos; se acota a 60 como la serie del ICC, no porque sobre historia sino porque la sparkline comprimiría 33 años y el movimiento reciente quedaría invisible.
- Los últimos puntos coinciden exacto con las cards (`3,87` y `125,6`), con el mismo redondeo, así que G3 cierra.

**Test nuevo.** Ningún gate cubría esto: `gate_calidad.py` compara card contra serie sólo cuando la serie **existe** (G3), y si no existe no tiene con qué comparar. `test_series_registradas.py` verifica que todo indicador publicado con valor numérico tenga su serie en el registro que resuelve `--indicador`, con una lista explícita para las excepciones a propósito. Verificado que no es vacuo: 65 indicadores contra 92 claves registradas, y sacando `alquiler_real` del registro el test falla.

## Verificación

A 390px contra el build local, las 7 rutas:

- cero scroll horizontal (era 1 ruta)
- cero casos del mismo número con dos formatos (eran 12 valores en 4 rutas)
- hero en 2 filas (eran 4)
- área táctil del tramo: 45px (eran 9)
- clamp de descripción: 4 líneas (eran 2)

`npm run build` OK (78 páginas) y **628 tests** en verde.

## Lo que NO toqué, a propósito

- **La tipografía de 8,5px** de la matriz de `/metodologia/`: el autor la puso con un comentario explícito («La matriz entra SIN scroll») — subirla reintroduce el scroll horizontal que evitó. Es un trade informado, no un descuido.
- **El número grande en JetBrains Mono** (`.cg-tile-num`), que hace que `0,8` se lea como `0 , 8` y `−23` como `− 23`: no es `letter-spacing`, es el ancho fijo de la celda de la mono. Cambiar la fuente de todos los valores es una decisión de diseño, no un bug — con `Montserrat` + `tabular-nums` se resolvería, pero conviene verlo antes.
- **Snapshots regenerados a medias.** Correr los tests reescribe `web/src/data/*.json` (importan `publicar`), pero deja `output/` sin tocar. Verifiqué que los diffs fueran sólo el signo menos y con `generated_at` idéntico, y los reverti igual: el cron regenera el par completo esta noche y ahí aparecen las sparklines y el texto con `−`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
